### PR TITLE
TKTC-9 Add Seeker API Support

### DIFF
--- a/Sources/CongregationKit/CongregationKit.docc/Documentation.md
+++ b/Sources/CongregationKit/CongregationKit.docc/Documentation.md
@@ -4,11 +4,11 @@ A high-level Swift SDK for TKT Church and other churches to integrate with Sales
 
 ## Overview
 
-`CongregationKit` provides a modern, async/await-based interface for accessing and managing church member data via Salesforce. It is dedicated to The King's Temple Church (TKT Church), but is also modular and extensible for use by other churches or organizations seeking robust, type-safe data models and protocols.
+`CongregationKit` provides a modern, async/await-based interface for accessing and managing church member and seeker data via Salesforce. It is dedicated to The King's Temple Church (TKT Church), but is also modular and extensible for use by other churches or organizations seeking robust, type-safe data models and protocols.
 
-- **Modular Models:** Member data is split into sub-structs (ContactInformation, EmploymentInformation, MaritalInformation, DiscipleshipInformation) for clarity and extensibility.
+- **Modular Models:** Member and seeker data are split into sub-structs for clarity and extensibility.
 - **Protocols:** All major data domains conform to protocols for type-safe, extensible access.
-- **Field Expansion:** Field expansion lets you fetch only the data you need, improving performance and clarity.
+- **Field Expansion:** Field expansion lets you fetch only the data you need, improving performance and clarity (for members).
 - **Async/Await:** All API calls are async/await and concurrency-safe (`Sendable`).
 - **Cross-Platform:** Works on macOS and iOS, and is ready for both server-side (Vapor/Hummingbird) and app use.
 - **Production-Ready:** Secure, well-documented, and tested for real-world church data.
@@ -26,13 +26,14 @@ let credentials = SalesforceCredentials(
     username: "your_username",
     password: "your_password"
 )
-let congregation = CongregationKit(httpClient: httpClient, credentials: credentials)
+let congregation = try await CongregationKit(httpClient: httpClient, credentials: credentials)
 let members = try await congregation.members.fetchAll(expanded: [.contactInformation, .employmentInformation])
+let seekers = try await congregation.seekers.fetchAll(pageNumber: 1, pageSize: 10, campus: .eastCampus, leadStatus: .attempted)
 ```
 
 ## Key Features
-- Modular, extensible models for member data
-- Field expansion for efficient data access
+- Modular, extensible models for member and seeker data
+- Field expansion for efficient member data access
 - Protocol-oriented design for maximum flexibility
 - Full async/await and concurrency safety
 - Designed for TKT Church, but reusable by any church or organization
@@ -45,9 +46,11 @@ let members = try await congregation.members.fetchAll(expanded: [.contactInforma
 
 ### Available Services
 - ``CongregationKit/members``
+- ``CongregationKit/seekers``
 
 ### Data Models
 - ``Member``
+- ``Seeker``
 - ``ContactInformation``
 - ``EmploymentInformation``
 - ``MaritalInformation``
@@ -58,6 +61,7 @@ let members = try await congregation.members.fetchAll(expanded: [.contactInforma
 - ``EmploymentInformationRepresentable``
 - ``MaritalInformationRepresentable``
 - ``DiscipleshipInformationRepresentable``
+- ``SeekerDataRepresentable``
 
 ## Dedication
 This SDK is dedicated to The King's Temple Church (TKT Church), Hyderabad, India and is open for use by any church or organization seeking to modernize their congregation management with Salesforce.

--- a/Sources/CongregationKit/CongregationKit.swift
+++ b/Sources/CongregationKit/CongregationKit.swift
@@ -42,6 +42,7 @@ public struct CongregationKit: CongregationKitProtocol {
     private let salesforceClient: SalesforceClient
     private let authResponse: SalesforceAuthResponse
     private let membersHandler: MembersHandler
+    private let seekersHandler: SeekersHandler
     
     /// Creates a new CongregationKit client and authenticates with Salesforce
     /// - Parameters:
@@ -52,6 +53,11 @@ public struct CongregationKit: CongregationKitProtocol {
         self.salesforceClient = SalesforceClient(httpClient: httpClient)
         self.authResponse = try await salesforceClient.auth.authenticate(credentials: credentials)
         self.membersHandler = SalesforceMembersHandler(
+            salesforceClient: salesforceClient,
+            accessToken: authResponse.accessToken,
+            instanceUrl: authResponse.instanceUrl
+        )
+        self.seekersHandler = SalesforceSeekersHandler(
             salesforceClient: salesforceClient,
             accessToken: authResponse.accessToken,
             instanceUrl: authResponse.instanceUrl
@@ -70,11 +76,21 @@ public struct CongregationKit: CongregationKitProtocol {
             accessToken: authResponse.accessToken,
             instanceUrl: authResponse.instanceUrl
         )
+        self.seekersHandler = SalesforceSeekersHandler(
+            salesforceClient: salesforceClient,
+            accessToken: authResponse.accessToken,
+            instanceUrl: authResponse.instanceUrl
+        )
     }
     
     /// The members handler for member operations
     public var members: MembersHandler {
         return membersHandler
+    }
+    
+    /// The seekers handler for seeker operations
+    public var seekers: SeekersHandler {
+        return seekersHandler
     }
 }
 

--- a/Sources/CongregationKit/Handlers/SeekersHandler.swift
+++ b/Sources/CongregationKit/Handlers/SeekersHandler.swift
@@ -1,0 +1,93 @@
+import Foundation
+import SalesforceClient
+
+/// Protocol for handling seeker operations
+///
+/// Provides methods to fetch all seekers or a specific seeker by identifier, with support for pagination and filtering.
+public protocol SeekersHandler: Sendable {
+    /// Fetches all seekers with pagination and optional filters
+    /// - Parameters:
+    ///   - pageNumber: The page number to fetch (optional, default 1)
+    ///   - pageSize: The page size to fetch (optional, default 50)
+    ///   - seekerId: Filter by seeker ID (optional)
+    ///   - name: Filter by name (optional)
+    ///   - campus: Filter by campus (optional, type-safe)
+    ///   - leadStatus: Filter by lead status (optional, type-safe)
+    ///   - email: Filter by email (optional)
+    ///   - leadId: Filter by lead ID (optional)
+    ///   - contactNumber: Filter by contact number (optional)
+    /// - Returns: SeekerResponse containing seekers and pagination info
+    /// - Throws: `SeekerError` if operation fails
+    func fetchAll(
+        pageNumber: Int?,
+        pageSize: Int?,
+        seekerId: String?,
+        name: String?,
+        campus: Campus?,
+        leadStatus: LeadStatus?,
+        email: String?,
+        leadId: String?,
+        contactNumber: String?
+    ) async throws -> SeekerResponse
+
+    /// Fetches a specific seeker by identifier (leadId or phone, case-insensitive)
+    /// - Parameters:
+    ///   - identifier: The identifier to fetch (leadId or phone)
+    /// - Returns: The seeker if found
+    /// - Throws: `SeekerError` if operation fails
+    func fetch(identifier: String) async throws -> Seeker
+}
+
+/// Default implementation of SeekersHandler for Salesforce
+public struct SalesforceSeekersHandler: SeekersHandler {
+    private let salesforceClient: SalesforceClient
+    private let accessToken: String
+    private let instanceUrl: String
+
+    /// Creates a new SalesforceSeekersHandler
+    /// - Parameters:
+    ///   - salesforceClient: The Salesforce client instance
+    ///   - accessToken: The OAuth access token
+    ///   - instanceUrl: The Salesforce instance URL
+    public init(salesforceClient: SalesforceClient, accessToken: String, instanceUrl: String) {
+        self.salesforceClient = salesforceClient
+        self.accessToken = accessToken
+        self.instanceUrl = instanceUrl
+    }
+
+    /// Fetches all seekers with pagination and optional filters
+    public func fetchAll(
+        pageNumber: Int? = nil,
+        pageSize: Int? = nil,
+        seekerId: String? = nil,
+        name: String? = nil,
+        campus: Campus? = nil,
+        leadStatus: LeadStatus? = nil,
+        email: String? = nil,
+        leadId: String? = nil,
+        contactNumber: String? = nil
+    ) async throws -> SeekerResponse {
+        return try await salesforceClient.seekers.fetchAll(
+            accessToken: accessToken,
+            instanceUrl: instanceUrl,
+            pageNumber: pageNumber,
+            pageSize: pageSize,
+            seekerId: seekerId,
+            name: name,
+            campus: campus,
+            leadStatus: leadStatus,
+            email: email,
+            leadId: leadId,
+            contactNumber: contactNumber
+        )
+    }
+
+    /// Fetches a specific seeker by identifier (leadId or phone, case-insensitive)
+    public func fetch(identifier: String) async throws -> Seeker {
+        return try await salesforceClient.seekers.fetch(
+            identifier: identifier,
+            accessToken: accessToken,
+            instanceUrl: instanceUrl
+        )
+    }
+} 

--- a/Sources/CongregationKit/Handlers/SeekersHandler.swift
+++ b/Sources/CongregationKit/Handlers/SeekersHandler.swift
@@ -36,6 +36,11 @@ public protocol SeekersHandler: Sendable {
     /// - Returns: The seeker if found
     /// - Throws: `SeekerError` if operation fails
     func fetch(identifier: String) async throws -> Seeker
+
+    /// Fetches all seekers (non-paginated)
+    /// - Returns: Array of seekers
+    /// - Throws: `SeekerError` if operation fails
+    func fetchAll() async throws -> [Seeker]
 }
 
 /// Default implementation of SeekersHandler for Salesforce
@@ -86,6 +91,16 @@ public struct SalesforceSeekersHandler: SeekersHandler {
     public func fetch(identifier: String) async throws -> Seeker {
         return try await salesforceClient.seekers.fetch(
             identifier: identifier,
+            accessToken: accessToken,
+            instanceUrl: instanceUrl
+        )
+    }
+
+    /// Fetches all seekers (non-paginated)
+    /// - Returns: Array of seekers
+    /// - Throws: `SeekerError` if operation fails
+    public func fetchAll() async throws -> [Seeker] {
+        return try await salesforceClient.seekers.fetchAll(
             accessToken: accessToken,
             instanceUrl: instanceUrl
         )

--- a/Sources/CongregationKit/Protocols/CongregationKitProtocol.swift
+++ b/Sources/CongregationKit/Protocols/CongregationKitProtocol.swift
@@ -4,4 +4,6 @@ import Foundation
 public protocol CongregationKitProtocol: Sendable {
     /// The members handler for member operations
     var members: MembersHandler { get }
+    /// The seekers handler for seeker operations
+    var seekers: SeekersHandler { get }
 }

--- a/Sources/SalesforceClient/Models/Members/Data/MemberData.swift
+++ b/Sources/SalesforceClient/Models/Members/Data/MemberData.swift
@@ -295,6 +295,7 @@ public enum Campus: String, Codable, CaseIterable, Sendable {
     case campusThree = "Campus Three"
     case campusFour = "Campus Four"
     case teenXYouth = "Teen X Youth"
+    case hiTechCity = "Hitech City"
 
     /// A user-friendly display name for the campus.
     public var displayName: String { self.rawValue }
@@ -302,18 +303,30 @@ public enum Campus: String, Codable, CaseIterable, Sendable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let value = try container.decode(String.self).trimmingCharacters(in: .whitespacesAndNewlines)
-        switch value {
-        case "East Campus": self = .eastCampus
-        case "West Campus": self = .westCampus
-        case "Campus One": self = .campusOne
-        case "Campus Two": self = .campusTwo
-        case "Campus Three": self = .campusThree
-        case "Campus Four": self = .campusFour
-        case "Teen X Youth": self = .teenXYouth
+        // Normalize inputs by converting to lowercase and removing all spaces
+        let normalizedValue = value.lowercased().replacingOccurrences(of: " ", with: "")
+        switch normalizedValue {
+        case "eastcampus":
+            self = .eastCampus
+        case "westcampus":
+            self = .westCampus
+        case "campusone":
+            self = .campusOne
+        case "campustwo":
+            self = .campusTwo
+        case "campusthree":
+            self = .campusThree
+        case "campusfour":
+            self = .campusFour
+        case "teenxyouth":
+            self = .teenXYouth
+        case "hitechcity":
+            self = .hiTechCity
         default:
             throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unknown Campus value: \(value)")
         }
     }
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(self.rawValue)

--- a/Sources/SalesforceClient/Models/Protocols/SeekerDataRepresentable.swift
+++ b/Sources/SalesforceClient/Models/Protocols/SeekerDataRepresentable.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// A protocol describing the common data fields for a seeker (lead/contact) as represented in Salesforce.
+///
+/// Types conforming to this protocol provide access to all standard seeker fields, including
+/// demographic, contact, and entry information. This protocol is designed for extensibility
+/// and can be used for any model representing seeker data from Salesforce.
+public protocol SeekerDataRepresentable: Codable, Sendable {
+    /// The seeker's unique identifier, if available.
+    var id: String? { get }
+    /// The lead information for the seeker, if available.
+    var lead: Lead? { get }
+    /// The seeker's full name, if available.
+    var fullName: String? { get }
+    /// The seeker's email address, if available.
+    var email: String? { get }
+    /// The seeker's phone number, if available.
+    var phone: String? { get }
+    /// The seeker's date of birth, if available.
+    var dateOfBirth: Date? { get }
+    /// The seeker's age group (derived or provided), if available.
+    var ageGroup: String? { get }
+    /// The seeker's area or locality, if available.
+    var area: String? { get }
+    /// The type of entry for the seeker (e.g., Salvation, New Visitor), if available.
+    var typeOfEntry: TypeOfEntry? { get }
+    /// The seeker's marital status, if available.
+    var maritalStatus: MaritalStatus? { get }
+    /// The date the seeker was created, if available.
+    var createdDate: Date? { get }
+    /// The seeker's age, calculated from dateOfBirth if available.
+    var age: Int? { get }
+}

--- a/Sources/SalesforceClient/Models/Seekers/Data/Seeker.swift
+++ b/Sources/SalesforceClient/Models/Seekers/Data/Seeker.swift
@@ -1,0 +1,373 @@
+import Foundation
+
+/// Represents a church seeker from Salesforce
+public struct Seeker: SeekerDataRepresentable, Equatable, Sendable {
+    /// The unique identifier for the seeker.
+    public let id: String?
+    /// The lead information for the seeker, if available.
+    public let lead: Lead?
+    /// The seeker's full name, if available.
+    public let fullName: String?
+    /// The seeker's email address, if available.
+    public let email: String?
+    /// The seeker's phone number, if available.
+    public let phone: String?
+    /// The seeker's date of birth, if available.
+    public let dateOfBirth: Date?
+    /// The seeker's age group (derived or provided).
+    public let ageGroup: String?
+    /// The seeker's area or locality, if available.
+    public let area: String?
+    /// The type of entry for the seeker (e.g., Salvation, New Visitor).
+    public let typeOfEntry: TypeOfEntry?
+    /// The seeker's marital status, if available.
+    public let maritalStatus: MaritalStatus?
+    /// The date the seeker was created, if available.
+    public let createdDate: Date?
+
+    /**
+     Creates a new Seeker instance.
+     - Parameters:
+        - id: The unique identifier for the seeker.
+        - lead: The lead information for the seeker, if available.
+        - fullName: The seeker's full name, if available.
+        - email: The seeker's email address, if available.
+        - phone: The seeker's phone number, if available.
+        - dateOfBirth: The seeker's date of birth, if available.
+        - ageGroup: The seeker's age group (derived or provided).
+        - area: The seeker's area or locality, if available.
+        - typeOfEntry: The type of entry for the seeker (e.g., Salvation, New Visitor).
+        - maritalStatus: The seeker's marital status, if available.
+        - createdDate: The date the seeker was created, if available.
+     */
+    public init(
+        id: String? = nil,
+        lead: Lead? = nil,
+        fullName: String? = nil,
+        email: String? = nil,
+        phone: String? = nil,
+        dateOfBirth: Date? = nil,
+        ageGroup: String? = nil,
+        area: String? = nil,
+        typeOfEntry: TypeOfEntry? = nil,
+        maritalStatus: MaritalStatus? = nil,
+        createdDate: Date? = nil
+    ) {
+        self.id = id
+        self.lead = lead
+        self.fullName = fullName
+        self.email = email
+        self.phone = phone
+        self.dateOfBirth = dateOfBirth
+        // Compute ageGroup from dateOfBirth if available, otherwise use provided ageGroup
+        if let dob = dateOfBirth {
+            let calendar = Calendar.current
+            let now = Date()
+            let ageComponents = calendar.dateComponents([.year], from: dob, to: now)
+            if let age = ageComponents.year {
+                switch age {
+                case 0..<18: self.ageGroup = "0-17"
+                case 18..<26: self.ageGroup = "18-25"
+                case 26..<36: self.ageGroup = "26-35"
+                case 36..<46: self.ageGroup = "36-45"
+                case 46..<56: self.ageGroup = "46-55"
+                default: self.ageGroup = "56+"
+                }
+            } else {
+                self.ageGroup = ageGroup
+            }
+        } else {
+            self.ageGroup = ageGroup
+        }
+        self.area = area
+        self.typeOfEntry = typeOfEntry
+        self.maritalStatus = maritalStatus
+        self.createdDate = createdDate
+    }
+
+    /// Coding keys for mapping API fields to struct properties.
+    enum CodingKeys: String, CodingKey {
+        case id
+        case leadId = "leadIdText"
+        case fullName = "nameLocal"
+        case email = "emailAlt"
+        case phone = "contactNumberMobile"
+        case dateOfBirth
+        case ageGroup = "age"
+        case area
+        case leadStatus
+        case typeOfEntry
+        case maritalStatus
+        case createdDate
+    }
+
+    /// The seeker's age, calculated from dateOfBirth if available.
+    public var age: Int? {
+        guard let dob = dateOfBirth else { return nil }
+        let calendar = Calendar.current
+        let now = Date()
+        let ageComponents = calendar.dateComponents([.year], from: dob, to: now)
+        return ageComponents.year
+    }
+
+    /// Equatable conformance for Seeker.
+    public static func == (lhs: Seeker, rhs: Seeker) -> Bool {
+        return lhs.id == rhs.id &&
+            lhs.lead == rhs.lead &&
+            lhs.fullName == rhs.fullName &&
+            lhs.email == rhs.email &&
+            lhs.phone == rhs.phone &&
+            lhs.dateOfBirth == rhs.dateOfBirth &&
+            lhs.ageGroup == rhs.ageGroup &&
+            lhs.area == rhs.area &&
+            lhs.typeOfEntry == rhs.typeOfEntry &&
+            lhs.maritalStatus == rhs.maritalStatus &&
+            lhs.createdDate == rhs.createdDate
+    }
+}
+
+extension Seeker: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let lead: Lead? = {
+            let id = try? container.decodeIfPresent(String.self, forKey: .id)
+            let status: LeadStatus? = {
+                if let rawValue = try? container.decodeIfPresent(String.self, forKey: .leadStatus),
+                   let value = LeadStatus(rawValue: rawValue) {
+                    return value
+                }
+                return nil
+            }()
+            if id != nil || status != nil {
+                return Lead(id: id, status: status)
+            }
+            return nil
+        }()
+        
+        let id = try container.decodeIfPresent(String.self, forKey: .id)
+        let fullName = try container.decodeIfPresent(String.self, forKey: .fullName)
+        let email = try container.decodeIfPresent(String.self, forKey: .email)
+        let phone = try container.decodeIfPresent(String.self, forKey: .phone)
+        let ageGroup = try container.decodeIfPresent(String.self, forKey: .ageGroup)
+        let dateOfBirth: Date? = {
+            if let dateString = try? container.decodeIfPresent(String.self, forKey: .dateOfBirth) {
+                let formatter = ISO8601DateFormatter()
+                return formatter.date(from: dateString)
+            }
+            return nil
+        }()
+        let area = try container.decodeIfPresent(String.self, forKey: .area)
+        
+        let typeOfEntry: TypeOfEntry? = {
+            if let rawValue = try? container.decodeIfPresent(String.self, forKey: .typeOfEntry),
+               let value = TypeOfEntry(rawValue: rawValue) {
+                return value
+            }
+            return nil
+        }()
+        
+        let maritalStatus: MaritalStatus? = {
+            if let rawValue = try? container.decodeIfPresent(String.self, forKey: .maritalStatus),
+               let value = MaritalStatus(rawValue: rawValue) {
+                return value
+            }
+            return nil
+        }()
+        
+        let createdDate: Date? = {
+            if let dateString = try? container.decodeIfPresent(String.self, forKey: .createdDate) {
+                let formatter = ISO8601DateFormatter()
+                return formatter.date(from: dateString)
+            }
+            return nil
+        }()
+
+        self.init(
+            id: id,
+            lead: lead,
+            fullName: fullName,
+            email: email,
+            phone: phone,
+            dateOfBirth: dateOfBirth,
+            ageGroup: ageGroup,
+            area: area,
+            typeOfEntry: typeOfEntry,
+            maritalStatus: maritalStatus,
+            createdDate: createdDate
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(lead?.id, forKey: .id)
+        try container.encodeIfPresent(lead?.status, forKey: .leadStatus)
+        try container.encodeIfPresent(fullName, forKey: .fullName)
+        try container.encodeIfPresent(email, forKey: .email)
+        try container.encodeIfPresent(phone, forKey: .phone)
+        try container.encodeIfPresent(dateOfBirth, forKey: .dateOfBirth)
+        try container.encodeIfPresent(ageGroup, forKey: .ageGroup)
+        try container.encodeIfPresent(area, forKey: .area)
+        try container.encodeIfPresent(typeOfEntry, forKey: .typeOfEntry)
+        try container.encodeIfPresent(maritalStatus, forKey: .maritalStatus)
+        try container.encodeIfPresent(createdDate, forKey: .createdDate)
+    }
+}
+
+/// Represents the type of entry for a seeker (e.g., Salvation, New Visitor).
+public enum TypeOfEntry: String, Codable, CaseIterable, Sendable {
+    /// The seeker is coming back.
+    case comingBack = "COMING BACK"
+    /// The seeker is a salvation entry.
+    case salvation = "SALVATION"
+    /// The seeker is a new visitor.
+    case newVisitor = "NEW VISITOR"
+    /// The seeker is a new visitor with salvation.
+    case newVisitorSalvation = "NEW VISITOR SALVATION"
+    /// Unknown type of entry.
+    case unknown
+
+    /// User-friendly display name for the type of entry.
+    public var displayName: String {
+        switch self {
+        case .comingBack: return "Coming Back"
+        case .salvation: return "Salvation"
+        case .newVisitor: return "New Visitor"
+        case .newVisitorSalvation: return "New Visitor Salvation"
+        case .unknown: return "Unknown"
+        }
+    }
+
+    /// Short display string for the type of entry.
+    public var shortDisplay: String {
+        switch self {
+        case .comingBack: return "Back"
+        case .salvation: return "Salvation"
+        case .newVisitor: return "Visitor"
+        case .newVisitorSalvation: return "Visitor+Salvation"
+        case .unknown: return "?"
+        }
+    }
+
+    /// Creates a new instance from a decoder.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self).trimmingCharacters(in: .whitespacesAndNewlines)
+        switch value.uppercased() {
+        case "COMING BACK": self = .comingBack
+        case "SALVATION": self = .salvation
+        case "NEW VISITOR": self = .newVisitor
+        case "NEW VISITOR SALVATION": self = .newVisitorSalvation
+        case "": self = .unknown
+        default: self = .unknown
+        }
+    }
+
+    /// Encodes this value into the given encoder.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self == .unknown ? "" : rawValue)
+    }
+}
+
+/// Represents a lead associated with a seeker.
+public struct Lead: Codable, Sendable, Equatable {
+    /// The unique identifier for the lead.
+    public let id: String?
+    /// The status of the lead, if available.
+    public let status: LeadStatus?
+
+    /**
+     Creates a new Lead instance.
+     - Parameters:
+        - id: The unique identifier for the lead.
+        - status: The status of the lead, if available.
+     */
+    public init(id: String? = nil, status: LeadStatus? = nil) {
+        self.id = id
+        self.status = status
+    }
+
+    /// Coding keys for mapping API fields to struct properties.
+    enum CodingKeys: String, CodingKey {
+        case id
+        case status = "leadStatus"
+    }
+}
+
+/// Represents the status of a lead (e.g., Attempted, Follow-up, Converted).
+public enum LeadStatus: String, Codable, CaseIterable, Sendable {
+    /// The lead was attempted.
+    case attempted = "Attempted"
+    /// The lead is in follow-up.
+    case followUp = "Follow-up"
+    /// The lead is in second follow-up.
+    case secondFollowUp = "2nd Follow up"
+    /// The lead is in third follow-up.
+    case thirdFollowUp = "3rd Follow up"
+    /// The lead is in fourth follow-up.
+    case fourthFollowUp = "4th Follow up"
+    /// The lead is lost.
+    case lost = "Lost"
+    /// The lead is converted.
+    case converted = "Converted"
+    /// The lead should not be contacted.
+    case doNotContact = "Do not contact"
+    /// Unknown lead status.
+    case unknown
+
+    /// User-friendly display name for the lead status.
+    public var displayName: String {
+        switch self {
+        case .attempted: return "Attempted"
+        case .followUp: return "Follow-up"
+        case .secondFollowUp: return "2nd Follow up"
+        case .thirdFollowUp: return "3rd Follow up"
+        case .fourthFollowUp: return "4th Follow up"
+        case .lost: return "Lost"
+        case .converted: return "Converted"
+        case .doNotContact: return "Do not contact"
+        case .unknown: return "Unknown"
+        }
+    }
+
+    /// Short display string for the lead status.
+    public var shortDisplay: String {
+        switch self {
+        case .attempted: return "Attempted"
+        case .followUp: return "Follow-up"
+        case .secondFollowUp: return "2nd FU"
+        case .thirdFollowUp: return "3rd FU"
+        case .fourthFollowUp: return "4th FU"
+        case .lost: return "Lost"
+        case .converted: return "Converted"
+        case .doNotContact: return "DNC"
+        case .unknown: return "?"
+        }
+    }
+
+    /// Creates a new instance from a decoder.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self).trimmingCharacters(in: .whitespacesAndNewlines)
+        switch value {
+        case "Attempted": self = .attempted
+        case "Follow-up": self = .followUp
+        case "2nd Follow up": self = .secondFollowUp
+        case "3rd Follow up": self = .thirdFollowUp
+        case "4th Follow up": self = .fourthFollowUp
+        case "Lost": self = .lost
+        case "Converted": self = .converted
+        case "Do not contact": self = .doNotContact
+        case "": self = .unknown
+        default: self = .unknown
+        }
+    }
+
+    /// Encodes this value into the given encoder.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self == .unknown ? "" : rawValue)
+    }
+}

--- a/Sources/SalesforceClient/Models/Seekers/Data/SeekerResponse.swift
+++ b/Sources/SalesforceClient/Models/Seekers/Data/SeekerResponse.swift
@@ -121,3 +121,24 @@ extension SeekerResponse {
         return (data.metadata.per, data.metadata.total, data.metadata.page)
     }
 }
+
+/// Errors specific to seeker operations
+public enum SeekerError: Error, LocalizedError, Sendable {
+    case seekerNotFound
+    case invalidSeekerData
+    case fetchFailed(Error)
+    case invalidIdentifier
+
+    public var errorDescription: String? {
+        switch self {
+        case .seekerNotFound:
+            return "Seeker not found"
+        case .invalidSeekerData:
+            return "Invalid seeker data received"
+        case .fetchFailed(let error):
+            return "Failed to fetch seeker data: \(error.localizedDescription)"
+        case .invalidIdentifier:
+            return "Identifier must be a valid leadId or phone number"
+        }
+    }
+}

--- a/Sources/SalesforceClient/Models/Seekers/Data/SeekerResponse.swift
+++ b/Sources/SalesforceClient/Models/Seekers/Data/SeekerResponse.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+/// Response wrapper for seeker data from API, supporting both paginated and non-paginated responses
+public struct SeekerResponse: Codable, Sendable {
+    /// Array of seekers returned from the API
+    public let seekers: [Seeker]
+    /// Optional data container for paginated responses
+    public let data: DataContainer?
+    /// Optional error flag
+    public let error: Bool?
+    /// Optional error message
+    public let message: String?
+
+    public struct DataContainer: Codable, Sendable {
+        public let items: [Seeker]
+        public let metadata: Metadata
+    }
+
+    public struct Metadata: Codable, Sendable {
+        public let per: Int
+        public let total: Int
+        public let page: Int
+    }
+
+    // Success initializer for non-paginated response
+    public init(seekers: [Seeker]) {
+        self.seekers = seekers
+        self.data = nil
+        self.error = nil
+        self.message = nil
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case seekers = "seeker" // Legacy key
+        case data
+        case error
+        case message
+        // API keys for paginated response
+        case items = "seekers"
+        case totalRecords
+        case pageSize
+        case pageNumber
+        case success
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // Check for error response
+        if let success = try? container.decodeIfPresent(Bool.self, forKey: .success), success == false {
+            self.seekers = []
+            self.data = nil
+            self.error = true
+            self.message = try? container.decodeIfPresent(String.self, forKey: .message)
+            return
+        }
+        self.error = nil
+        self.message = nil
+        // Try decoding paginated response
+        if let seekers = try? container.decodeIfPresent([Seeker].self, forKey: .items) {
+            let per = (try? container.decodeIfPresent(Int.self, forKey: .pageSize)) ?? seekers.count
+            let total = (try? container.decodeIfPresent(Int.self, forKey: .totalRecords)) ?? seekers.count
+            let page = (try? container.decodeIfPresent(Int.self, forKey: .pageNumber)) ?? 1
+            self.seekers = seekers
+            self.data = DataContainer(items: seekers, metadata: Metadata(per: per, total: total, page: page))
+        }
+        // Fall back to legacy non-paginated response ("seeker")
+        else if let seekers = try? container.decodeIfPresent([Seeker].self, forKey: .seekers) {
+            self.seekers = seekers
+            self.data = nil
+        } else {
+            self.seekers = []
+            self.data = nil
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        // Encode paginated response
+        if let data = data {
+            try container.encode(data, forKey: .data)
+        }
+        // Encode non-paginated response
+        else {
+            try container.encode(seekers, forKey: .seekers)
+        }
+        if let error = error {
+            try container.encode(error, forKey: .error)
+            try container.encode(false, forKey: .success)
+        }
+        if let message = message {
+            try container.encode(message, forKey: .message)
+        }
+    }
+}
+
+extension SeekerResponse {
+    // Convenience initializer for paginated response
+    public init(seekers: [Seeker], per: Int, total: Int, page: Int) {
+        self.seekers = seekers
+        self.data = DataContainer(items: seekers, metadata: Metadata(per: per, total: total, page: page))
+        self.error = nil
+        self.message = nil
+    }
+
+    // Convenience initializer for error response
+    public init(errorMessage: String) {
+        self.seekers = []
+        self.data = nil
+        self.error = true
+        self.message = errorMessage
+    }
+
+    // Helper to check if response is paginated
+    public var isPaginated: Bool {
+        return data != nil
+    }
+
+    // Helper to access pagination info safely
+    public var paginationInfo: (per: Int, total: Int, page: Int)? {
+        guard let data = data else { return nil }
+        return (data.metadata.per, data.metadata.total, data.metadata.page)
+    }
+}

--- a/Sources/SalesforceClient/Protocols/SalesforceAPIRoute.swift
+++ b/Sources/SalesforceClient/Protocols/SalesforceAPIRoute.swift
@@ -139,4 +139,11 @@ public protocol SalesforceSeekerRoutes: SalesforceAPIRoute {
      - Throws: `SeekerError` if seeker not found or fetch fails
      */
     func fetch(identifier: String, accessToken: String, instanceUrl: String) async throws -> Seeker
+
+    /// Fetches all seekers from Salesforce (returns all seekers, not paginated)
+    /// - Parameter accessToken: The OAuth access token
+    /// - Parameter instanceUrl: The Salesforce instance URL
+    /// - Returns: Array of seekers
+    /// - Throws: `SeekerError` if fetch fails
+    func fetchAll(accessToken: String, instanceUrl: String) async throws -> [Seeker]
 } 

--- a/Sources/SalesforceClient/Protocols/SalesforceAPIRoute.swift
+++ b/Sources/SalesforceClient/Protocols/SalesforceAPIRoute.swift
@@ -94,4 +94,49 @@ public protocol SalesforceMemberRoutes: SalesforceAPIRoute {
      - Throws: `MemberError` if member not found, fetch fails, or validation fails.
      */
     func fetch(memberId: MemberID, accessToken: String, instanceUrl: String, expanded: [MemberExpand]) async throws -> Member
+}
+
+/// Protocol for Salesforce seeker routes
+public protocol SalesforceSeekerRoutes: SalesforceAPIRoute {
+    /**
+     Fetches a paginated list of seekers from Salesforce.
+     - Parameters:
+        - accessToken: The OAuth access token
+        - instanceUrl: The Salesforce instance URL
+        - pageNumber: The page number to fetch (optional, default 1)
+        - pageSize: The page size to fetch (optional, default 50)
+        - seekerId: Filter by seeker ID (optional)
+        - name: Filter by name (optional)
+        - campus: Filter by campus (optional)
+        - leadStatus: Filter by lead status (optional)
+        - email: Filter by email (optional)
+        - leadId: Filter by lead ID (optional)
+        - contactNumber: Filter by contact number (optional)
+     - Returns: SeekerResponse containing seekers and pagination info
+     - Throws: `SeekerError` if fetch fails
+     */
+    func fetchAll(
+        accessToken: String,
+        instanceUrl: String,
+        pageNumber: Int?,
+        pageSize: Int?,
+        seekerId: String?,
+        name: String?,
+        campus: Campus?,
+        leadStatus: LeadStatus?,
+        email: String?,
+        leadId: String?,
+        contactNumber: String?
+    ) async throws -> SeekerResponse
+
+    /**
+     Fetches a specific seeker by identifier (leadId or phone, case-insensitive).
+     - Parameters:
+        - identifier: The identifier to fetch (leadId or phone)
+        - accessToken: The OAuth access token
+        - instanceUrl: The Salesforce instance URL
+     - Returns: The seeker if found
+     - Throws: `SeekerError` if seeker not found or fetch fails
+     */
+    func fetch(identifier: String, accessToken: String, instanceUrl: String) async throws -> Seeker
 } 

--- a/Sources/SalesforceClient/Routes/SalesforceSeekerRoutes.swift
+++ b/Sources/SalesforceClient/Routes/SalesforceSeekerRoutes.swift
@@ -53,6 +53,22 @@ public struct SalesforceSeekerRoutesImpl: SalesforceSeekerRoutes {
         return try await client.processResponse(response, as: SeekerResponse.self)
     }
 
+    /// Fetches all seekers from Salesforce (returns all seekers, not paginated)
+    public func fetchAll(accessToken: String, instanceUrl: String) async throws -> [Seeker] {
+        let seekerURL = "\(instanceUrl)\(SalesforceAPIConstants.seekerEndpointV2)"
+        let requestHeaders = SalesforceAPIUtil.convertToHTTPHeaders([
+            "Authorization": "Bearer \(accessToken)",
+            "Content-Type": "application/json"
+        ])
+        let response = try await client.sendRequest(
+            method: .GET,
+            path: seekerURL,
+            headers: requestHeaders
+        )
+        let seekerResponse = try await client.processResponse(response, as: SeekerResponse.self)
+        return seekerResponse.seekers
+    }
+
     /// Fetches a specific seeker by identifier (leadId or phone, case-insensitive).
     public func fetch(identifier: String, accessToken: String, instanceUrl: String) async throws -> Seeker {
         let seekerURL = "\(instanceUrl)\(SalesforceAPIConstants.seekerEndpointV2)/\(identifier)"
@@ -71,5 +87,5 @@ public struct SalesforceSeekerRoutesImpl: SalesforceSeekerRoutes {
         }
         return seeker
     }
-} 
+}
  

--- a/Sources/SalesforceClient/Routes/SalesforceSeekerRoutes.swift
+++ b/Sources/SalesforceClient/Routes/SalesforceSeekerRoutes.swift
@@ -1,0 +1,75 @@
+import Foundation
+import AsyncHTTPClient
+import NIOHTTP1
+
+/// Implementation of Salesforce seeker routes
+public struct SalesforceSeekerRoutesImpl: SalesforceSeekerRoutes {
+    public var headers: HTTPHeaders = [:]
+    private let client: SalesforceAPIHandler
+    
+    init(client: SalesforceAPIHandler) {
+        self.client = client
+    }
+
+    /// Fetches a paginated list of seekers from Salesforce.
+    public func fetchAll(
+        accessToken: String,
+        instanceUrl: String,
+        pageNumber: Int?,
+        pageSize: Int?,
+        seekerId: String?,
+        name: String?,
+        campus: Campus?,
+        leadStatus: LeadStatus?,
+        email: String?,
+        leadId: String?,
+        contactNumber: String?
+    ) async throws -> SeekerResponse {
+        let page = pageNumber ?? 1
+        let size = pageSize ?? 50
+        var queryParams: [String: String] = [
+            "pageNumber": String(page),
+            "pageSize": String(size)
+        ]
+        if let seekerId = seekerId { queryParams["seekerId"] = seekerId }
+        if let name = name { queryParams["name"] = name }
+        if let campus = campus { queryParams["campus"] = campus.rawValue }
+        if let leadStatus = leadStatus { queryParams["leadStatus"] = leadStatus.rawValue }
+        if let email = email { queryParams["email"] = email }
+        if let leadId = leadId { queryParams["leadId"] = leadId }
+        if let contactNumber = contactNumber { queryParams["contactNumber"] = contactNumber }
+
+        let seekerURL = "\(instanceUrl)\(SalesforceAPIConstants.seekerEndpointV2)"
+        let requestHeaders = SalesforceAPIUtil.convertToHTTPHeaders([
+            "Authorization": "Bearer \(accessToken)",
+            "Content-Type": "application/json"
+        ])
+        let response = try await client.sendRequest(
+            method: .GET,
+            path: seekerURL,
+            queryParams: queryParams,
+            headers: requestHeaders
+        )
+        return try await client.processResponse(response, as: SeekerResponse.self)
+    }
+
+    /// Fetches a specific seeker by identifier (leadId or phone, case-insensitive).
+    public func fetch(identifier: String, accessToken: String, instanceUrl: String) async throws -> Seeker {
+        let seekerURL = "\(instanceUrl)\(SalesforceAPIConstants.seekerEndpointV2)/\(identifier)"
+        let requestHeaders = SalesforceAPIUtil.convertToHTTPHeaders([
+            "Authorization": "Bearer \(accessToken)",
+            "Content-Type": "application/json"
+        ])
+        let response = try await client.sendRequest(
+            method: .GET,
+            path: seekerURL,
+            headers: requestHeaders
+        )
+        let seekerResponse = try await client.processResponse(response, as: SeekerResponse.self)
+        guard let seeker = seekerResponse.seekers.first else {
+            throw SeekerError.seekerNotFound
+        }
+        return seeker
+    }
+} 
+ 

--- a/Sources/SalesforceClient/SalesforceClient.swift
+++ b/Sources/SalesforceClient/SalesforceClient.swift
@@ -43,6 +43,9 @@ public actor SalesforceClient {
     /// Routes for Salesforce member management
     public let members: any SalesforceMemberRoutes
     
+    /// Routes for Salesforce seeker management
+    public let seekers: any SalesforceSeekerRoutes
+    
     private let handler: SalesforceAPIHandler
     
     /// Creates a new Salesforce API client.
@@ -51,6 +54,7 @@ public actor SalesforceClient {
         self.handler = SalesforceAPIHandler(httpClient: httpClient)
         self.auth = SalesforceAuthRoutesImpl(client: handler)
         self.members = SalesforceMemberRoutesImpl(client: handler)
+        self.seekers = SalesforceSeekerRoutesImpl(client: handler)
     }
 }
 


### PR DESCRIPTION
This PR adds full support for managing "seekers" (in addition to members) in CongregationKit. It introduces new protocols, handlers, and client routes for seekers, enabling paginated and filtered seeker queries, as well as single seeker lookups. The update includes:

- Type-safe seeker API routes and models
- `SeekersHandler` protocol and `SalesforceSeekersHandler` implementation
- Integration of seekers into `CongregationKit` and `SalesforceClient`
- Updated documentation and usage examples

Now, you can fetch seekers just like members, with async/await and type safety throughout the SDK.